### PR TITLE
Update test cas to illustrate bug suspected

### DIFF
--- a/org/postgresql/test/jdbc2/CursorFetchTest.java
+++ b/org/postgresql/test/jdbc2/CursorFetchTest.java
@@ -372,7 +372,7 @@ public class CursorFetchTest extends TestCase
         int rowCount = 4;
         createRows(rowCount);
         
-        int[] sizes = { 2, 3 };
+        int[] sizes = { 3, 2 };
         for (int i = 0; i < sizes.length; ++i)
         {
             Statement stmt = con.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
@@ -398,10 +398,10 @@ public class CursorFetchTest extends TestCase
                 else
                     assertTrue(msg, !rs.isFirst());
                 
-                if (j == rowCount - 1)
-                    assertTrue(msg, rs.isLast());
-                else
-                    assertTrue(msg, !rs.isLast());
+//                if (j == rowCount - 1)
+//                    assertTrue(msg, rs.isLast());
+//                else
+//                    assertTrue(msg, !rs.isLast());
             }
             
             msg = "after-last row positioning error with fetchsize=" + sizes[i];


### PR DESCRIPTION
http://www.postgresql.org/message-id/OFF3D569C5.9BC4DC3D-ONC1257E1B.0045CF5C-C1257E1B.00472393@retraite.lan

I remove isLast check because it changes Resultset state and make isAfterLast call always OK
